### PR TITLE
Increase textbox length to avoid truncating ifttt keys

### DIFF
--- a/website/morpheuz/view.html
+++ b/website/morpheuz/view.html
@@ -237,7 +237,7 @@
                     <label for="ifkey">Key:</label>
                   </div>
                   <div class="cell">
-                    <input id="ifkey" type="text" maxlength="30" class="textbox wide" />
+                    <input id="ifkey" type="text" maxlength="50" class="textbox wide" />
                   </div>
                 </div>
                 <p class="small">Setting this value will send a 'morpheuz-alarm' &amp; a 'morpheuz-data' event to IFTTT at alarm time &amp; the normal export time respectively.</p>


### PR DESCRIPTION
I don't know if older maker keys were shorter, but I just created my maker key on ifttt today and was given a key that is 43 characters long. Unfortunately, the webpage to input this key into morpheuz only allowed a maximum of 30 characters. 

This pull request ups the limit to 50 (just in case my key at 43 characters isn't the longest possible key).

Thank you so much for developing Morpheuz. I've recently switched from Sleep as Android and hope to contribute more in the future.

Best wishes,
Scott